### PR TITLE
Harness for execute assembly, execute assembly for msvc bofs

### DIFF
--- a/Payload_Type/xenon/xenon/agent_code/Makefile
+++ b/Payload_Type/xenon/xenon/agent_code/Makefile
@@ -45,6 +45,12 @@ artifact_x64.sc.dll: $(SRC_FILES)
 artifact_x64-debug.sc.dll: $(SRC_FILES)
 	$(CC) $^ -o $@ -shared -D_SHELLCODE $(CFLAGS) $(LFLAGS) $(DFLAGS)
 
+harness: tools/harness.exe
+
+tools/harness.exe: $(SRC_FILES) tools/harness.c
+	$(CC) tools/harness.c Src/Utils.c Src/BeaconCompatibility.c Src/Tasks/InlineExecute.c \
+	    -o tools/harness.exe -Wall -w -g -IInclude -D_DEBUG -D_MANUAL -DHARNESS_BUILD $(LFLAGS)
+
 # Clean up
 clean:
-	rm -f *.dll *.exe *.bin
+	rm -f *.dll *.exe *.bin tools/harness.exe

--- a/Payload_Type/xenon/xenon/agent_code/Src/BeaconCompatibility.c
+++ b/Payload_Type/xenon/xenon/agent_code/Src/BeaconCompatibility.c
@@ -252,9 +252,12 @@ void BeaconPrintf(int type, char* fmt, ...) {
     int length = 0;
     char* tempptr = NULL;
     va_list args;
+    /* In the harness, suppress live vprintf — output is read via BeaconGetOutputData() */
+#ifndef HARNESS_BUILD
     va_start(args, fmt);
     vprintf(fmt, args);
     va_end(args);
+#endif
 
     va_start(args, fmt);
     length = vsnprintf(NULL, 0, fmt, args);

--- a/Payload_Type/xenon/xenon/agent_code/Src/Tasks/InlineExecute.c
+++ b/Payload_Type/xenon/xenon/agent_code/Src/Tasks/InlineExecute.c
@@ -12,6 +12,24 @@
     Most code is from here https://github.com/Ap3x/COFF-Loader/tree/main/Src
 */
 
+/* Additional AMD64 relocation types produced by MSVC but not MinGW */
+#define IMAGE_REL_AMD64_REL32_1     0x0005
+#define IMAGE_REL_AMD64_REL32_2     0x0006
+#define IMAGE_REL_AMD64_REL32_3     0x0007
+#define IMAGE_REL_AMD64_REL32_4     0x0008
+#define IMAGE_REL_AMD64_REL32_5     0x0009
+
+/* Section Characteristics for filtering MSVC metadata sections */
+#ifndef IMAGE_SCN_LNK_INFO
+#define IMAGE_SCN_LNK_INFO          0x00000200
+#endif
+#ifndef IMAGE_SCN_LNK_REMOVE
+#define IMAGE_SCN_LNK_REMOVE        0x00000800
+#endif
+#ifndef IMAGE_SCN_MEM_DISCARDABLE
+#define IMAGE_SCN_MEM_DISCARDABLE   0x02000000
+#endif
+
 /*
     COFF Loader Supporting Functions
 */
@@ -21,7 +39,10 @@ BOOL InternalFunctionMatch(char* StrippedSymbolName) {
         STR_EQUALS(StrippedSymbolName, "GetModuleHandleA") ||
         STR_EQUALS(StrippedSymbolName, "toWideChar") ||
         STR_EQUALS(StrippedSymbolName, "LoadLibraryA") ||
-        STR_EQUALS(StrippedSymbolName, "FreeLibrary"))
+        STR_EQUALS(StrippedSymbolName, "FreeLibrary") ||
+        STR_EQUALS(StrippedSymbolName, "__C_specific_handler") ||
+        STR_EQUALS(StrippedSymbolName, "__GSHandlerCheck") ||
+        STR_EQUALS(StrippedSymbolName, "__GSHandlerCheck_SEH"))
     {
         return TRUE;
     }
@@ -56,29 +77,52 @@ void* ProcessBeaconSymbols(char* SymbolName, BOOL InternalFunction) {
         }
     }
     else {
-        //_dbg("\t\tExternal Symbol\n");
+        _dbg("\t\tExternal Symbol\n");
         locallib = strtok_s(localSymbolNameCopy + sizeof(PREPENDSYMBOLVALUE) - 1, "$", &context);
         llHandle = LoadLibraryA(locallib);
+        if (llHandle == NULL) return NULL; /* no '$' in name or library not found */
 
-        //_dbg("\t\tHandle: 0x%lx\n", llHandle);
+        _dbg("\t\tHandle: 0x%lx\n", llHandle);
         localfunc = strtok_s(NULL, "$", &context);
+        if (localfunc == NULL) return NULL;
         localfunc = strtok_s(localfunc, "@", &context);
         functionaddress = GetProcAddress(llHandle, localfunc);
-        //_dbg("\t\tProcAddress: 0x%p\n", functionaddress);
+        _dbg("\t\tProcAddress: 0x%p\n", functionaddress);
         return functionaddress;
     }
+    return NULL;
 }
 
-BOOL ExecuteEntry(COFF_t* COFF, char* func, char* args, unsigned long argSize) {
+BOOL ExecuteEntry(COFF_t* COFF, void** SectionMapped, char* func, char* args, unsigned long argSize) {
     VOID(*foo)(char* in, UINT32 datalen) = NULL;
 
     if (!func || !COFF->FileBase)
         _dbg("No entry provided");
 
-    for (UINT32 counter = 0; counter < COFF->FileHeader->NumberOfSymbols; counter++)
+    /* String table immediately follows the symbol table */
+    char* stringTable = (char*)(COFF->SymbolTable + COFF->FileHeader->NumberOfSymbols);
+    for (UINT32 counter = 0; counter < COFF->FileHeader->NumberOfSymbols;
+         counter += 1 + COFF->SymbolTable[counter].NumberOfAuxSymbols)
     {
-        if (strcmp(COFF->SymbolTable[counter].first.Name, func) == 0) {
-            foo = (void(*)(char*, UINT32))((char*)COFF->RawTextData + COFF->SymbolTable[counter].Value);
+        /* Resolve symbol name: inline (<= 8 bytes) or via string table offset */
+        char* symName;
+        char inlineName[9] = {0};
+        if (COFF->SymbolTable[counter].first.Name[0] != 0) {
+            memcpy(inlineName, COFF->SymbolTable[counter].first.Name, 8);
+            symName = inlineName;
+        } else {
+            symName = stringTable + COFF->SymbolTable[counter].first.value[1];
+        }
+        if (strcmp(symName, func) == 0) {
+            /* Use the symbol's own SectionNumber to find the right mapped section.
+               RawTextData is NOT used — MSVC names the text section ".text$mn", not ".text",
+               so any approach relying on section name matching fails for MSVC BOFs. */
+            UINT16 secNum = COFF->SymbolTable[counter].SectionNumber;
+            if (secNum == 0 || SectionMapped[secNum - 1] == NULL) {
+                _dbg("Entry symbol found but section not loaded (secNum=%d)\n", secNum);
+                continue;
+            }
+            foo = (void(*)(char*, UINT32))((char*)SectionMapped[secNum - 1] + COFF->SymbolTable[counter].Value);
             _dbg("Trying to run: 0x%p\n\n", foo);
         }
     }
@@ -95,23 +139,32 @@ void RelocationTypeParse(COFF_t* COFF, void** SectionMapped, int SectionNumber, 
     UINT64 longOffsetAddr = 0;
     unsigned int Type = COFF->Relocation->Type;
 
-    if (Type == IMAGE_REL_AMD64_ADDR64) 
+    /* Guard: skip when there is no resolved function address AND the symbol either:
+         - has SectionNumber == 0 (undefined external) → sectionMapped[-1] out-of-bounds
+         - references a section that was filtered/not loaded (NULL mapping) */
+    if (FunctionAddrPTR == NULL) {
+        UINT16 symSecNum = COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber;
+        if (symSecNum == 0) return;
+        if (SectionMapped[symSecNum - 1] == NULL) return;
+    }
+
+    if (Type == IMAGE_REL_AMD64_ADDR64)
     {
         memcpy(&longOffsetAddr, (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, sizeof(UINT64));
-        //_dbg("\tReadin longOffsetValue : 0x%llX\n", longOffsetAddr);
+        _dbg("\tReadin longOffsetValue : 0x%llX\n", longOffsetAddr);
         longOffsetAddr = (UINT64)((char*)SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1] + (UINT64)longOffsetAddr);
         longOffsetAddr += COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value;
-        //_dbg("\tModified longOffsetValue : 0x%llX Base Address: %p\n", longOffsetAddr, SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1]);
+        _dbg("\tModified longOffsetValue : 0x%llX Base Address: %p\n", longOffsetAddr, SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1]);
         memcpy((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, &longOffsetAddr, sizeof(UINT64));
     }
     else if (COFF->Relocation->Type == IMAGE_REL_AMD64_ADDR32NB) {
         memcpy(&offsetAddr, (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, sizeof(INT32));
-        //_dbg("\tReadin OffsetValue : 0x%0X\n", offsetAddr);
-        //_dbg("\t\tReferenced Section: 0x%X\n", (char*)SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1] + offsetAddr);
-        //_dbg("\t\tEnd of Relocation Bytes: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress + 4);
+        _dbg("\tReadin OffsetValue : 0x%0X\n", offsetAddr);
+        _dbg("\t\tReferenced Section: 0x%X\n", (char*)SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1] + offsetAddr);
+        _dbg("\t\tEnd of Relocation Bytes: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress + 4);
         offsetAddr = ((char*)((char*)SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1] + offsetAddr) - ((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress + 4));
         offsetAddr += COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value;
-        //_dbg("\tSetting 0x%p to OffsetValue: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, offsetAddr);
+        _dbg("\tSetting 0x%p to OffsetValue: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, offsetAddr);
         memcpy((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, &offsetAddr, sizeof(UINT32));
     }
     else if (Type == IMAGE_REL_AMD64_REL32) {
@@ -119,7 +172,7 @@ void RelocationTypeParse(COFF_t* COFF, void** SectionMapped, int SectionNumber, 
             memcpy(FunctionMapping + (COFF->FunctionMappingCount * 8), &FunctionAddrPTR, sizeof(UINT64));
             offsetAddr = (INT32)((FunctionMapping + (COFF->FunctionMappingCount * 8) ) - ((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress + 4));
             offsetAddr += COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value;
-            //_dbg("\t\tSetting internal function at 0x%p to relative address: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, offsetAddr);
+            _dbg("\t\tSetting internal function at 0x%p to relative address: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, offsetAddr);
             memcpy((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, &offsetAddr, sizeof(UINT32));
             InternalFunction = FALSE;
             COFF->FunctionMappingCount++;
@@ -127,21 +180,42 @@ void RelocationTypeParse(COFF_t* COFF, void** SectionMapped, int SectionNumber, 
         else {
             // This should copy the relative offset for the specified data section into offsetAddr
             memcpy(&offsetAddr, (void*)((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress), sizeof(UINT32));
-            //_dbg("\tReadin Offset Value : 0x%llX\n", offsetAddr);
+            _dbg("\tReadin Offset Value : 0x%llX\n", offsetAddr);
             // Getting the symbols section then adding the offset to get the value stored.
             offsetAddr += (UINT32)((char*)SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1] - ((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress + 4));
             // Since the StorageClass is going to be IMAGE_SYM_CLASS_STATIC or IMAGE_SYM_CLASS_EXTERNAL with a non-zero SymbolTableIndex
             offsetAddr += COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value;
-            //_dbg("\t\tSetting 0x%p to relative address: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, offsetAddr);
+            _dbg("\t\tSetting 0x%p to relative address: 0x%X\n", (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, offsetAddr);
             memcpy((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, &offsetAddr, sizeof(UINT32));
         }
     }
-    else 
+    else if (Type >= IMAGE_REL_AMD64_REL32_1 && Type <= IMAGE_REL_AMD64_REL32_5)
     {
-        //_dbg("[!] Relocation Type Not Implemented\n");
+        /* Same as REL32 but the encoded addend includes an extra N-byte adjustment
+           (used by MSVC for RIP-relative refs inside multi-byte instructions). */
+        int adjustment = Type - IMAGE_REL_AMD64_REL32;
+        if (FunctionAddrPTR != NULL) {
+            memcpy(FunctionMapping + (COFF->FunctionMappingCount * 8), &FunctionAddrPTR, sizeof(UINT64));
+            offsetAddr = (INT32)((FunctionMapping + (COFF->FunctionMappingCount * 8)) - ((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress + 4));
+            offsetAddr += COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value;
+            offsetAddr -= adjustment;
+            memcpy((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, &offsetAddr, sizeof(UINT32));
+            COFF->FunctionMappingCount++;
+        }
+        else {
+            memcpy(&offsetAddr, (void*)((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress), sizeof(UINT32));
+            offsetAddr += (UINT32)((char*)SectionMapped[COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber - 1] - ((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress + 4));
+            offsetAddr += COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value;
+            offsetAddr -= adjustment;
+            memcpy((char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, &offsetAddr, sizeof(UINT32));
+        }
     }
-    //_dbg("\tValueNumber: 0x%X\n", COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value);
-    //_dbg("\tSectionNumber: 0x%X\n", COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber);
+    else
+    {
+        _dbg("[!] Relocation Type Not Implemented\n");
+    }
+    _dbg("\tValueNumber: 0x%X\n", COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].Value);
+    _dbg("\tSectionNumber: 0x%X\n", COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber);
 }
 
 BOOL RunCOFF(char* FileData, DWORD* DataSize, char* EntryName, char* argumentdata, unsigned long argumentsize)
@@ -165,10 +239,21 @@ BOOL RunCOFF(char* FileData, DWORD* DataSize, char* EntryName, char* argumentdat
 
     for (byte i = 0; i < COFF.FileHeader->NumberOfSections; i++) {
         Section_t* section = (Section_t*)(COFF.FileBase + sizeof(FileHeader_t) + (i * sizeof(Section_t)));
-        //_dbg("********* COFF Section %d: \"%s\" *********\n", i, section->Name);
+        _dbg("********* COFF Section %d: \"%s\" *********\n", i, section->Name);
+
+        /* Skip MSVC metadata sections:
+             .drectve, .debug$*          — flagged LNK_INFO / LNK_REMOVE / DISCARDABLE
+             .pdata, .xdata, .chks64     — exception tables / unwind info / checksum;
+                                           flagged as plain data so must be excluded by name */
+        if (section->Characteristics & (IMAGE_SCN_LNK_REMOVE | IMAGE_SCN_LNK_INFO | IMAGE_SCN_MEM_DISCARDABLE) ||
+            strncmp(section->Name, ".pdata", 6) == 0 ||
+            strncmp(section->Name, ".xdata", 6) == 0) {
+            sectionMapped[i] = NULL;
+            continue;
+        }
 
         sectionMapped[i] = (char*)VirtualAlloc(NULL, section->SizeOfRawData, MEM_COMMIT | MEM_RESERVE | MEM_TOP_DOWN, PAGE_EXECUTE_READWRITE);
-        //_dbg("Allocated section %d at 0x%p\n", i, sectionMapped[i]);
+        _dbg("Allocated section %d at 0x%p\n", i, sectionMapped[i]);
 
         if (section->PointerToRawData != 0) {
             memcpy(sectionMapped[i], COFF.FileBase + section->PointerToRawData, section->SizeOfRawData);
@@ -184,14 +269,15 @@ BOOL RunCOFF(char* FileData, DWORD* DataSize, char* EntryName, char* argumentdat
         COFF.RelocationsCount += section->NumberOfRelocations;
     }
 
-    //_dbg("Total Relocations: %d\n", COFF.RelocationsCount);
+    _dbg("Total Relocations: %d\n", COFF.RelocationsCount);
 
     functionMapping = (char*)VirtualAlloc(NULL, COFF.RelocationsCount * 8, MEM_COMMIT | MEM_RESERVE | MEM_TOP_DOWN, PAGE_EXECUTE_READWRITE);
     int currentSection = 0;
     for (int s = 0; s < COFF.FileHeader->NumberOfSections; s++) {
+        if (sectionMapped[s] == NULL) continue; /* filtered/skipped section */
         Section_t* section = (Section_t*)(COFF.FileBase + sizeof(FileHeader_t) + (s * sizeof(Section_t)));
         COFF.RelocationsTextPTR = COFF.FileBase + section->PointerToRelocations;
-        //_dbg("********* Performing Relocations for \"%s\" Section *********\n", section->Name);
+        _dbg("********* Performing Relocations for \"%s\" Section *********\n", section->Name);
         
         for (int i = 0; i < section->NumberOfRelocations; i++) {
 
@@ -222,7 +308,7 @@ BOOL RunCOFF(char* FileData, DWORD* DataSize, char* EntryName, char* argumentdat
 ///////////////
 /// EXECUTE ///
 ///////////////
-    ExecuteEntry(&COFF, EntryName, argumentdata, argumentsize);
+    ExecuteEntry(&COFF, sectionMapped, EntryName, argumentdata, argumentsize);
 ///////////////
 /// EXECUTE ///
 ///////////////
@@ -248,11 +334,15 @@ BOOL RunCOFF(char* FileData, DWORD* DataSize, char* EntryName, char* argumentdat
 
 /**
  * @brief Execute a Beacon Object File in current process thread.
- * 
+ *
+ * Excluded from HARNESS_BUILD — the harness calls RunCOFF() directly,
+ * so Package/Parser/Task dependencies are not needed.
+ *
  * @param[in] taskUuid Task's UUID
  * @param[inout] arguments PARSER struct containing task data.
  * @return VOID
  */
+#ifndef HARNESS_BUILD
 VOID InlineExecute(PCHAR taskUuid, PPARSER arguments)
 {
     /* Parse command arguments */
@@ -313,5 +403,6 @@ VOID InlineExecute(PCHAR taskUuid, PPARSER arguments)
     free(OutData);                  // allocated in BeaconOutput()
     PackageDestroy(locals);
 }
+#endif  //HARNESS_BUILD
 
 #endif  //INCLUDE_CMD_INLINE_EXECUTE

--- a/Payload_Type/xenon/xenon/agent_code/tools/Makefile
+++ b/Payload_Type/xenon/xenon/agent_code/tools/Makefile
@@ -1,0 +1,36 @@
+# Xenon BOF Test Harness
+#
+# Run from agent_code/ directory:
+#   make -f tools/Makefile
+#
+# Or from this directory:
+#   make
+#
+# Output: tools/harness.exe  (copy to Windows target for testing)
+
+CC     = x86_64-w64-mingw32-gcc
+ROOT   = ..
+INC    = $(ROOT)/Include
+SRC    = $(ROOT)/Src
+
+# _DEBUG   — enables _dbg/_err printf output
+# _MANUAL  — Config.h enables all INCLUDE_CMD_* macros (incl. INLINE_EXECUTE)
+# HARNESS_BUILD — excludes InlineExecute() Mythic dispatcher (no Package/Parser deps)
+CFLAGS = -Wall -w -g -I$(INC) -D_DEBUG -D_MANUAL -DHARNESS_BUILD
+
+SRCS = tools/harness.c \
+       $(SRC)/Utils.c \
+       $(SRC)/BeaconCompatibility.c \
+       $(SRC)/Tasks/InlineExecute.c
+
+LIBS = -liphlpapi -lnetapi32 -lwininet -lws2_32
+
+.PHONY: all clean
+
+all: tools/harness.exe
+
+tools/harness.exe: $(SRCS)
+	$(CC) $(SRCS) -o tools/harness.exe $(CFLAGS) $(LIBS)
+
+clean:
+	rm -f tools/harness.exe

--- a/Payload_Type/xenon/xenon/agent_code/tools/harness.c
+++ b/Payload_Type/xenon/xenon/agent_code/tools/harness.c
@@ -1,0 +1,267 @@
+/*
+ * Xenon BOF Test Harness
+ *
+ * Loads a COFF/BOF object file from disk, packs typed arguments, executes it
+ * via RunCOFF(), and prints BeaconPrintf/BeaconOutput to stdout — no Mythic
+ * server or agent deployment required.
+ *
+ * Build (from agent_code/):
+ *   make -f tools/Makefile
+ *
+ * Usage:
+ *   harness.exe <bof.o> [entrypoint] [args...]
+ *
+ *   entrypoint  defaults to "go". Omit if using typed args immediately.
+ *
+ * Argument types (TYPE:VALUE):
+ *   z:<str>     NUL-terminated string          → BeaconDataExtract
+ *   Z:<str>     NUL-terminated wide string     → BeaconDataExtract
+ *   i:<int>     32-bit signed integer          → BeaconDataInt  (hex OK: 0x1a2b)
+ *   s:<int>     16-bit signed short            → BeaconDataShort
+ *   b:<file>    Binary blob read from <file>   → BeaconDataExtract
+ *
+ * Examples:
+ *   harness.exe whoami.x64.o
+ *   harness.exe dir.x64.o go z:C:\Temp
+ *   harness.exe netuser.x64.o go z:Administrator z:DOMAIN
+ *   harness.exe inject.x64.o go i:1234 b:payload.bin
+ */
+
+/* --- Build-time flags ---------------------------------------------------- */
+#define _DEBUG           /* enable _dbg/_err printf logging                  */
+#define _MANUAL          /* Config.h: enable all INCLUDE_CMD_* macros         */
+#define HARNESS_BUILD    /* exclude InlineExecute() Mythic dispatcher         */
+
+/* --- Standard headers ---------------------------------------------------- */
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* --- Project headers (include path set to agent_code/Include in Makefile) - */
+#include "Xenon.h"
+#include "BeaconCompatibility.h"
+#include "Tasks/InlineExecute.h"
+
+/* =========================================================================
+ * Global stubs — satisfy extern declarations pulled in by Xenon.h /
+ * BeaconCompatibility.c without linking the full agent.
+ * ======================================================================= */
+
+static CONFIG_XENON harness_cfg;         /* zero-initialised; set spawnto in main() */
+PCONFIG_XENON xenonConfig = &harness_cfg;
+
+/* Identity globals (declared extern in Identity.h) */
+HANDLE gIdentityToken     = NULL;
+BOOL   gIdentityIsLoggedIn = FALSE;
+WCHAR* gIdentityDomain    = NULL;
+
+/* Identity function stubs */
+BOOL IdentityIsAdmin(void)                             { return FALSE; }
+VOID IdentityImpersonateToken(void)                    {}
+VOID IdentityAgentRevertToken(void)                    {}
+BOOL IdentityGetUserInfo(HANDLE h, char* b, int s)     { return FALSE; }
+
+/* =========================================================================
+ * Argument packing
+ *
+ * Produces the binary buffer that BeaconDataParse() consumes:
+ *
+ *   [4-byte big-endian payload_size][packed args...]
+ *
+ * BeaconDataParse skips the first 4 bytes (treats them as the total length
+ * field), then subsequent reads pull typed values from the remaining bytes:
+ *
+ *   BeaconDataInt    — 4-byte big-endian int32
+ *   BeaconDataShort  — 2-byte big-endian int16
+ *   BeaconDataExtract — [4-byte BE length][raw bytes]  (strings, blobs)
+ * ======================================================================= */
+
+typedef struct { uint8_t* data; size_t len; size_t cap; } Buf;
+
+static void buf_init(Buf* b) {
+    b->cap  = 256;
+    b->data = (uint8_t*)malloc(b->cap);
+    b->len  = 0;
+}
+
+static void buf_append(Buf* b, const void* src, size_t n) {
+    while (b->len + n > b->cap) { b->cap *= 2; b->data = (uint8_t*)realloc(b->data, b->cap); }
+    memcpy(b->data + b->len, src, n);
+    b->len += n;
+}
+
+static void buf_be32(Buf* b, uint32_t v) {
+    uint8_t x[4] = { (uint8_t)(v>>24), (uint8_t)(v>>16), (uint8_t)(v>>8), (uint8_t)v };
+    buf_append(b, x, 4);
+}
+
+static void buf_be16(Buf* b, uint16_t v) {
+    uint8_t x[2] = { (uint8_t)(v>>8), (uint8_t)v };
+    buf_append(b, x, 2);
+}
+
+/*
+ * pack_args — convert TYPE:VALUE command-line tokens to a BOF argument buffer.
+ * Returns a malloc'd buffer; caller frees. Sets *out_len to total buffer size.
+ */
+static uint8_t* pack_args(int n, char** tokens, size_t* out_len) {
+    Buf payload;
+    buf_init(&payload);
+
+    for (int i = 0; i < n; i++) {
+        if (strlen(tokens[i]) < 2 || tokens[i][1] != ':') {
+            fprintf(stderr, "[!] Argument %d must be TYPE:VALUE (e.g. z:hello, i:42)\n", i + 1);
+            exit(1);
+        }
+        char  type = tokens[i][0];
+        char* val  = tokens[i] + 2;
+
+        switch (type) {
+        case 'z': {
+            uint32_t slen = (uint32_t)(strlen(val) + 1);
+            buf_be32(&payload, slen);
+            buf_append(&payload, val, slen);
+            break;
+        }
+        case 'Z': {
+            int wchars = MultiByteToWideChar(CP_ACP, 0, val, -1, NULL, 0);
+            WCHAR* ws = (WCHAR*)malloc(wchars * sizeof(WCHAR));
+            MultiByteToWideChar(CP_ACP, 0, val, -1, ws, wchars);
+            uint32_t blen = (uint32_t)(wchars * sizeof(WCHAR));
+            buf_be32(&payload, blen);
+            buf_append(&payload, ws, blen);
+            free(ws);
+            break;
+        }
+        case 'i':
+            buf_be32(&payload, (uint32_t)(int32_t)strtol(val, NULL, 0));
+            break;
+        case 's':
+            buf_be16(&payload, (uint16_t)(int16_t)strtol(val, NULL, 0));
+            break;
+        case 'b': {
+            FILE* f = fopen(val, "rb");
+            if (!f) { fprintf(stderr, "[!] Cannot open blob file: %s\n", val); exit(1); }
+            fseek(f, 0, SEEK_END); long fsz = ftell(f); rewind(f);
+            uint8_t* blob = (uint8_t*)malloc((size_t)fsz);
+            fread(blob, 1, (size_t)fsz, f); fclose(f);
+            buf_be32(&payload, (uint32_t)fsz);
+            buf_append(&payload, blob, (size_t)fsz);
+            free(blob);
+            break;
+        }
+        default:
+            fprintf(stderr, "[!] Unknown argument type '%c'. Valid types: z Z i s b\n", type);
+            exit(1);
+        }
+    }
+
+    /* Prepend 4-byte header (BeaconDataParse skips these) */
+    Buf final;
+    buf_init(&final);
+    buf_be32(&final, (uint32_t)payload.len);
+    buf_append(&final, payload.data, payload.len);
+    free(payload.data);
+
+    *out_len = final.len;
+    return final.data;
+}
+
+/* =========================================================================
+ * main
+ * ======================================================================= */
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr,
+            "Xenon BOF Test Harness\n"
+            "\n"
+            "Usage: harness.exe <bof.o> [entrypoint] [args...]\n"
+            "\n"
+            "  entrypoint  BOF entry function (default: go)\n"
+            "              Omit if the next argument is a typed arg.\n"
+            "\n"
+            "Argument types:\n"
+            "  z:<value>   NUL-terminated string  (BeaconDataExtract)\n"
+            "  Z:<value>   NUL-terminated wide string\n"
+            "  i:<value>   32-bit int, dec or 0x hex  (BeaconDataInt)\n"
+            "  s:<value>   16-bit short  (BeaconDataShort)\n"
+            "  b:<file>    Binary blob read from <file>  (BeaconDataExtract)\n"
+            "\n"
+            "Examples:\n"
+            "  harness.exe whoami.x64.o\n"
+            "  harness.exe dir.x64.o go z:C:\\Temp\n"
+            "  harness.exe netuser.x64.o go z:Administrator z:DOMAIN\n"
+        );
+        return 1;
+    }
+
+    /* Provide a valid spawnto path for any BOF that calls BeaconGetSpawnTo */
+    harness_cfg.spawnto = "svchost.exe";
+
+    const char* bof_path = argv[1];
+
+    /* Determine entrypoint: if argv[2] contains ':' it is a typed arg, not a name */
+    const char* entry  = "go";
+    int args_start     = 2;
+    if (argc >= 3 && strchr(argv[2], ':') == NULL) {
+        entry      = argv[2];
+        args_start = 3;
+    }
+
+    /* ---- Load BOF from disk ---- */
+    FILE* f = fopen(bof_path, "rb");
+    if (!f) { fprintf(stderr, "[!] Cannot open BOF: %s\n", bof_path); return 1; }
+    fseek(f, 0, SEEK_END);
+    long bof_size = ftell(f);
+    rewind(f);
+    char* bof_data = (char*)malloc((size_t)bof_size);
+    if (!bof_data) { fclose(f); fprintf(stderr, "[!] OOM\n"); return 1; }
+    fread(bof_data, 1, (size_t)bof_size, f);
+    fclose(f);
+
+    printf("[*] BOF:   %s (%ld bytes)\n", bof_path, bof_size);
+    printf("[*] Entry: %s\n", entry);
+
+    /* ---- Pack arguments ---- */
+    size_t   arg_len = 0;
+    uint8_t* arg_buf = NULL;
+    int      n_args  = argc - args_start;
+
+    if (n_args > 0) {
+        printf("[*] Args:  %d argument(s)\n", n_args);
+        arg_buf = pack_args(n_args, argv + args_start, &arg_len);
+    } else {
+        /* BeaconDataParse always expects the 4-byte header */
+        arg_buf = (uint8_t*)calloc(1, 4);
+        arg_len = 4;
+    }
+
+    /* ---- Execute ---- */
+    printf("[*] Running...\n\n");
+    DWORD sz = (DWORD)bof_size;
+    BOOL  ok = RunCOFF(bof_data, &sz, (char*)entry, (char*)arg_buf, (unsigned long)arg_len);
+
+    /* ---- Print output ---- */
+    int   out_size = 0;
+    char* out_data = BeaconGetOutputData(&out_size);
+
+    printf("\n");
+    if (out_data && out_size > 0) {
+        printf("======== BeaconOutput (%d bytes) ========\n", out_size);
+        fwrite(out_data, 1, (size_t)out_size, stdout);
+        if (out_data[out_size - 1] != '\n') printf("\n");
+        printf("=========================================\n");
+        free(out_data);
+    } else {
+        printf("[*] No BeaconOutput captured.\n");
+    }
+
+    if (!ok) fprintf(stderr, "[!] RunCOFF returned FALSE\n");
+
+    free(bof_data);
+    free(arg_buf);
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
Still testing this but a potential fix for #9 

My changes have gone a bit deeper than required for testing locally without needing a full C2 setup for each iteration. Maybe beyond scope a bit.

Same BOF as compiled before that crashed in #9 
<img width="1169" height="235" alt="image" src="https://github.com/user-attachments/assets/3347fd8f-7632-48ca-bc65-cb97545e7ab8" />

Same BOF compiled with mingw-gcc (which you demonstrated already worked - just to prove non-breaking in this particular case)
<img width="1175" height="232" alt="image" src="https://github.com/user-attachments/assets/f67579c3-095e-4b3e-a8cc-a3152825e366" />

It's not ready to merge, but I've tested inline execute and raising in case it's helpful.