### PR TITLE
Minimised changes to allow loading MSVC BOF's

### DIFF
--- a/Payload_Type/xenon/xenon/agent_code/Include/Tasks/InlineExecute.h
+++ b/Payload_Type/xenon/xenon/agent_code/Include/Tasks/InlineExecute.h
@@ -81,6 +81,7 @@ typedef struct COFF {
     Symbol_t* SymbolTable;
 
     void* RawTextData;
+    void** SectionMapped;
     char* RelocationsTextPTR;
     int RelocationsCount;
     int FunctionMappingCount;

--- a/Payload_Type/xenon/xenon/agent_code/Src/Tasks/InlineExecute.c
+++ b/Payload_Type/xenon/xenon/agent_code/Src/Tasks/InlineExecute.c
@@ -75,10 +75,25 @@ BOOL ExecuteEntry(COFF_t* COFF, char* func, char* args, unsigned long argSize) {
     if (!func || !COFF->FileBase)
         _dbg("No entry provided");
 
-    for (UINT32 counter = 0; counter < COFF->FileHeader->NumberOfSymbols; counter++)
+    char* stringTable = (char*)(COFF->SymbolTable + COFF->FileHeader->NumberOfSymbols);
+    for (UINT32 counter = 0; counter < COFF->FileHeader->NumberOfSymbols;
+         counter += 1 + COFF->SymbolTable[counter].NumberOfAuxSymbols)
     {
-        if (strcmp(COFF->SymbolTable[counter].first.Name, func) == 0) {
-            foo = (void(*)(char*, UINT32))((char*)COFF->RawTextData + COFF->SymbolTable[counter].Value);
+        char* symName;
+        char inlineName[9] = {0};
+        if (COFF->SymbolTable[counter].first.Name[0] != 0) {
+            memcpy(inlineName, COFF->SymbolTable[counter].first.Name, 8);
+            symName = inlineName;
+        } else {
+            symName = stringTable + COFF->SymbolTable[counter].first.value[1];
+        }
+        if (strcmp(symName, func) == 0) {
+            UINT16 secNum = COFF->SymbolTable[counter].SectionNumber;
+            if (secNum == 0 || COFF->SectionMapped[secNum - 1] == NULL) {
+                //_dbg("Entry symbol found but section not loaded (secNum=%d)\n", secNum);
+                continue;
+            }
+            foo = (void(*)(char*, UINT32))((char*)COFF->SectionMapped[secNum - 1] + COFF->SymbolTable[counter].Value);
             _dbg("Trying to run: 0x%p\n\n", foo);
         }
     }
@@ -95,7 +110,13 @@ void RelocationTypeParse(COFF_t* COFF, void** SectionMapped, int SectionNumber, 
     UINT64 longOffsetAddr = 0;
     unsigned int Type = COFF->Relocation->Type;
 
-    if (Type == IMAGE_REL_AMD64_ADDR64) 
+    if (FunctionAddrPTR == NULL) {
+        UINT16 symSecNum = COFF->SymbolTable[COFF->Relocation->SymbolTableIndex].SectionNumber;
+        if (symSecNum == 0) return;
+        if (SectionMapped[symSecNum - 1] == NULL) return;
+    }
+
+    if (Type == IMAGE_REL_AMD64_ADDR64)
     {
         memcpy(&longOffsetAddr, (char*)SectionMapped[SectionNumber] + COFF->Relocation->VirtualAddress, sizeof(UINT64));
         //_dbg("\tReadin longOffsetValue : 0x%llX\n", longOffsetAddr);
@@ -156,6 +177,7 @@ BOOL RunCOFF(char* FileData, DWORD* DataSize, char* EntryName, char* argumentdat
     
     char* functionMapping = NULL;
     void** sectionMapped = (void**)calloc(sizeof(char*) * (COFF.FileHeader->NumberOfSections + 1), 1);
+    COFF.SectionMapped = sectionMapped;
 
     if ((int)COFF.FileHeader->Machine != IMAGE_FILE_MACHINE_AMD64) {
         _dbg("[!] This common object file format is not supported yet :)");
@@ -189,6 +211,7 @@ BOOL RunCOFF(char* FileData, DWORD* DataSize, char* EntryName, char* argumentdat
     functionMapping = (char*)VirtualAlloc(NULL, COFF.RelocationsCount * 8, MEM_COMMIT | MEM_RESERVE | MEM_TOP_DOWN, PAGE_EXECUTE_READWRITE);
     int currentSection = 0;
     for (int s = 0; s < COFF.FileHeader->NumberOfSections; s++) {
+        if (sectionMapped[s] == NULL) continue; /* filtered/skipped section */
         Section_t* section = (Section_t*)(COFF.FileBase + sizeof(FileHeader_t) + (s * sizeof(Section_t)));
         COFF.RelocationsTextPTR = COFF.FileBase + section->PointerToRelocations;
         //_dbg("********* Performing Relocations for \"%s\" Section *********\n", section->Name);

--- a/Payload_Type/xenon/xenon/agent_code/Src/Tasks/InlineExecute.c
+++ b/Payload_Type/xenon/xenon/agent_code/Src/Tasks/InlineExecute.c
@@ -73,33 +73,45 @@ BOOL ExecuteEntry(COFF_t* COFF, char* func, char* args, unsigned long argSize) {
     VOID(*foo)(char* in, UINT32 datalen) = NULL;
 
     if (!func || !COFF->FileBase)
-        _dbg("No entry provided");
+	{
+		_dbg("No entry provided");
+		return FALSE;
+	}
 
     char* stringTable = (char*)(COFF->SymbolTable + COFF->FileHeader->NumberOfSymbols);
-    for (UINT32 counter = 0; counter < COFF->FileHeader->NumberOfSymbols;
-         counter += 1 + COFF->SymbolTable[counter].NumberOfAuxSymbols)
+    for (UINT32 counter = 0; counter < COFF->FileHeader->NumberOfSymbols; counter += 1 + COFF->SymbolTable[counter].NumberOfAuxSymbols)
     {
         char* symName;
         char inlineName[9] = {0};
-        if (COFF->SymbolTable[counter].first.Name[0] != 0) {
+        if (COFF->SymbolTable[counter].first.Name[0] != 0)
+		{
             memcpy(inlineName, COFF->SymbolTable[counter].first.Name, 8);
             symName = inlineName;
-        } else {
+        }
+		else 
+		{
             symName = stringTable + COFF->SymbolTable[counter].first.value[1];
         }
-        if (strcmp(symName, func) == 0) {
+		
+        if (strcmp(symName, func) == 0)
+		{
             UINT16 secNum = COFF->SymbolTable[counter].SectionNumber;
-            if (secNum == 0 || COFF->SectionMapped[secNum - 1] == NULL) {
+            if (secNum == 0 || COFF->SectionMapped[secNum - 1] == NULL)
+			{
                 //_dbg("Entry symbol found but section not loaded (secNum=%d)\n", secNum);
                 continue;
             }
             foo = (void(*)(char*, UINT32))((char*)COFF->SectionMapped[secNum - 1] + COFF->SymbolTable[counter].Value);
-            _dbg("Trying to run: 0x%p\n\n", foo);
         }
     }
 
     if (!foo)
-        _dbg("Couldn't find entry point");
+	{
+		_dbg("Couldn't find entry point");
+		return FALSE;
+	}
+
+	_dbg("Trying to run: 0x%p\n\n", foo);
 
     foo((char*)args, argSize);
     return TRUE;


### PR DESCRIPTION
Thanks for the time earlier, proposing this as a fix for #9 

Reraising against the latest feature version branch as per contribution guidelines, and removed all the test harness functionality and debug lines from testing. Rolled back a lot of changes and retested that didn't appear to be needed to run the small PoC MSVC compiled BOF. 

Hope this helps things. I've checked both versions as well as some built in functionality.

I'll do some digging on base64url client POST transform  soon, but it might be a while. I can raise what I have now if useful, but haven't tested for impact against, say, client GET base64url, which I think the padding change might break and probably what went wrong in the first place So it probably needs a little more work than I've done there. Its available if you want it as a less messy draft though. Cheers.