### PR TITLE
Reimplement POST base64url

### DIFF
--- a/Payload_Type/xenon/xenon/agent_code/Src/Transform.c
+++ b/Payload_Type/xenon/xenon/agent_code/Src/Transform.c
@@ -107,7 +107,6 @@ BOOL TransformApply(TRANSFORM* transform, PBYTE bufferIn, UINT32 bufferLen, unsi
 	{
 		switch (step)
 		{
-            case TRANSFORM_BASE64URL:
 			case TRANSFORM_BASE64:
 			{
                 // _dbg("[TRANSFORM_BASE64] Applying...");
@@ -143,42 +142,42 @@ BOOL TransformApply(TRANSFORM* transform, PBYTE bufferIn, UINT32 bufferLen, unsi
                 LocalFree(temp_encoded);
                 break;
 			}
-            // TODO : Not working with HTTPX profile
-            // case TRANSFORM_BASE64URL:
-            // {
-            //     _dbg("[TRANSFORM_BASE64URL] Applying...");//DEBUG
+            
+            case TRANSFORM_BASE64URL:
+            {
+                _dbg("[TRANSFORM_BASE64URL] Applying...");//DEBUG
 
-            //     outlen = calculate_base64_encoded_size(transformedLength);
-            //     char* temp_encoded = (char *)LocalAlloc(LPTR, outlen + 1);
+                outlen = calculate_base64_encoded_size(transformedLength);
+                char* temp_encoded = (char *)LocalAlloc(LPTR, outlen + 1);
 
-            //     if (temp_encoded == NULL)
-            //     {
-            //         _err("Base64_url encoding failed");
-            //         return FALSE;
-            //     }
+                if (temp_encoded == NULL)
+                {
+                    _err("Base64_url encoding failed");
+                    return FALSE;
+                }
 
-            //     int status = base64url_encode((const unsigned char *)transform->transformed,  transformedLength, temp_encoded, &outlen);
-            //     if (status != 0) {
-            //         LocalFree(temp_encoded);
-            //         return FALSE;
-            //     }
+                int status = base64url_encode((const unsigned char *)transform->transformed,  transformedLength, temp_encoded, &outlen);
+                if (status != 0) {
+                    LocalFree(temp_encoded);
+                    return FALSE;
+                }
 
 
-            //     if (outlen > transform->outputLength)
-            //     {
-            //         _err("Base64_url encoded data exceeds buffer size. Encoded size: %d, Buffer size: %d", outlen, transform->outputLength);
-            //         LocalFree(temp_encoded);
-            //         return FALSE;
-            //     }
+                if (outlen > transform->outputLength)
+                {
+                    _err("Base64_url encoded data exceeds buffer size. Encoded size: %d, Buffer size: %d", outlen, transform->outputLength);
+                    LocalFree(temp_encoded);
+                    return FALSE;
+                }
 
-            //     memset(transform->transformed, 0, transform->outputLength);
-            //     memcpy(transform->transformed, temp_encoded, outlen);
+                memset(transform->transformed, 0, transform->outputLength);
+                memcpy(transform->transformed, temp_encoded, outlen);
 
-            //     transformedLength = outlen;
+                transformedLength = outlen;
 
-            //     LocalFree(temp_encoded);
-            //     break;
-			// }
+                LocalFree(temp_encoded);
+                break;
+			}
             // XOR encodes payload
             case TRANSFORM_XOR:
             {

--- a/Payload_Type/xenon/xenon/agent_code/Src/Utils.c
+++ b/Payload_Type/xenon/xenon/agent_code/Src/Utils.c
@@ -174,7 +174,7 @@ int base64_encode(const unsigned char *in, unsigned long inlen,
 /* Public function for Base64 URL encoding */
 int base64url_encode(const unsigned char *in, unsigned long inlen,
                      char *out, unsigned long *outlen) {
-    return s_base64_encode_internal(in, inlen, out, outlen, codes_base64url, nopad);
+    return s_base64_encode_internal(in, inlen, out, outlen, codes_base64url, pad);
 }
 
 /*


### PR DESCRIPTION
This is readding the existing base64 URL transforms implementation, the only functional change required was adding padding when calling the internal encoder.

I've tested it in POST and GET cookies, and this is working with both base64url and base64, so I'm happy there. I've also tested  thinking padding would break get.client.message where location is "query" - and this is probably where the **problem with this PR** comes in - the good news is it works, but obviously it has trailing "=" padding which.. isn't great.. edit: same problem applies to cookies on second thoughts.

Assuming HTTPX supports no padding on query and cookies, it probably needs to branch off for query strings for dropping padding. This isn't implemented here, sorry. As it works for all the cases I tested I'm just raising as is.

The good news is this means the C2 documentation xenon shows for httpx profiles now works, as it was base64 url heavy, and it's probably not ideal having documentation be broken cases.